### PR TITLE
Remove Extra Check

### DIFF
--- a/src/Market/Onchain.hs
+++ b/src/Market/Onchain.hs
@@ -61,8 +61,7 @@ mkBuyValidator pkh nfts r ctx =
                  traceIfFalse "Seller not paid" checkSellerOut &&
                  traceIfFalse "Fee not paid" checkMarketplaceFee &&
                  traceIfFalse "Royalities not paid" checkRoyaltyFee
-        Close -> traceIfFalse "No rights to perform this action" checkCloser &&
-                 traceIfFalse "Close output invalid" checkCloseOut
+        Close -> traceIfFalse "No rights to perform this action" checkCloser
   where
     info :: TxInfo
     info = scriptContextTxInfo ctx
@@ -113,9 +112,6 @@ mkBuyValidator pkh nfts r ctx =
 
     checkCloser :: Bool
     checkCloser = txSignedBy info seller
-
-    checkCloseOut :: Bool
-    checkCloseOut = valueOf (valuePaidTo info seller) cs tn == 1
 
 
 data Sale


### PR DESCRIPTION
I removed an extra check on cancel.

Although this check has good intentions, it could lead to a situation where the user is unable to delist if the datum for the listing was setup incorrectly.

In other words, if the transaction to lock the asset with policyA.Asset1 has a datum specifying policyB.Asset1, the locking will work but the user will never be able to unlock via cancel (or not easily at least).

Additionally, this check prevents easy relisting by cancelling and sending the assets back to the script address. 

All around not a good check.